### PR TITLE
Implement mitigation for https://www.kb.cert.org/vuls/id/475445 as suggested by @jebeaudet

### DIFF
--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -254,7 +254,7 @@ public class SamlClient {
 
     Response response;
     try {
-      DOMParser parser = new DOMParser();
+      DOMParser parser = createDOMParser();
       parser.parse(new InputSource(new StringReader(decodedResponse)));
       response =
           (Response)
@@ -482,9 +482,26 @@ public class SamlClient {
     }
   }
 
+  private static DOMParser createDOMParser() throws SamlException {
+    DOMParser parser =
+        new DOMParser() {
+          {
+            try {
+              setFeature(INCLUDE_COMMENTS_FEATURE, false);
+            } catch (Throwable ex) {
+              throw new SamlException(
+                  "Cannot disable comments parsing to mitigate https://www.kb.cert.org/vuls/id/475445",
+                  ex);
+            }
+          }
+        };
+
+    return parser;
+  }
+
   private static MetadataProvider createMetadataProvider(Reader metadata) throws SamlException {
     try {
-      DOMParser parser = new DOMParser();
+      DOMParser parser = createDOMParser();
       parser.parse(new InputSource(metadata));
       DOMMetadataProvider provider =
           new DOMMetadataProvider(parser.getDocument().getDocumentElement());


### PR DESCRIPTION
This supercedes https://github.com/coveo/saml-client/pull/4 with the fix that @jebeaudet suggested (sorry @dreisch-coveo this wasn't fast enough 😛). The UT checks that the original identity is returned even when a comment has been injected.