### PR TITLE
Add notBeforeSkew option

### DIFF
--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -473,8 +473,7 @@ public class SamlClient {
     DateTime skewedNotBefore = notBefore.minus(notBeforeSkew);
     if (now.isBefore(skewedNotBefore)) {
       throw new SamlException(
-          "The assertion cannot be used before " + skewedNotBefore.toString() + " (" + notBefore.toString() +
-              " + " + notBeforeSkew + "ms skew)");
+          "The assertion cannot be used before " + notBefore.toString());
     }
 
     DateTime notOnOrAfter = conditions.getNotOnOrAfter();

--- a/src/test/java/com/coveo/saml/SamlClientTest.java
+++ b/src/test/java/com/coveo/saml/SamlClientTest.java
@@ -183,4 +183,28 @@ public class SamlClientTest {
     // ensure that the identity that ends up being returned is the proper one.
     assertEquals("mlaporte@coveo.com", response.getNameID());
   }
+
+  @Test
+  public void decodeAndValidateSamlResponseWorksWithNowAfterSkewedNotBefore() throws Throwable {
+    SamlClient client =
+            SamlClient.fromMetadata(
+                    "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
+    int skew = 60 * 60 * 1000;
+    client.setDateTimeNow(ASSERTION_DATE.minus(skew));
+    client.setNotBeforeSkew(skew);
+    SamlResponse response = client.decodeAndValidateSamlResponse(AN_ENCODED_RESPONSE);
+    assertEquals("mlaporte@coveo.com", response.getNameID());
+  }
+
+
+  @Test(expected = SamlException.class)
+  public void decodeAndValidateSamlResponseRejectsNowBeforeNotBefore() throws Throwable {
+    SamlClient client =
+            SamlClient.fromMetadata(
+                    "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
+    int skew = 60 * 60 * 1000;
+    client.setDateTimeNow(ASSERTION_DATE.minus(skew));
+    SamlResponse response = client.decodeAndValidateSamlResponse(AN_ENCODED_RESPONSE);
+    assertEquals("mlaporte@coveo.com", response.getNameID());
+  }
 }


### PR DESCRIPTION
When the clock of the identity provider is ahead of the relying party, a SAML assertion may end up having a notBefore date that appears to be in the future. This causes the assertion to be rejected. It would be nice if we could tell SamlClient that we're willing to accept some skew in server time to prevent these assertions failing.

Because assertions already take into account that there may be latency between servers, it does not seem necesary to me to skew the notOnOrAfter date. If we do want this it would be very simple to skew both notBefore and notOnOrAfter, though.

ADFS provides an option _notBeforeSkew_ that allows you to accept assertions that appear to be in the future by a certain amount. This pull request introduces a similar feature to saml-client.

See [ADFS docs](https://docs.microsoft.com/en-us/powershell/module/adfs/set-adfsrelyingpartytrust?view=win10-ps) for more info on the flag. (ctrl-f notbeforeskew)

[This blog](http://rmichaelmead.com/adfs-not-before-time-skew/) contains a short how-to (not by me) of using the ADFS version.

If there are any changes you'd like to see I'd be happy to implement them.

Kind regards
