### PR TITLE
#9: Move to OpenSAML 3.x.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.iml
 .idea
 target
+
+.project
+.classpath
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.coveo</groupId>
   <artifactId>saml-client</artifactId>
-  <version>1.7.0</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -49,6 +49,8 @@
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+
+    <opensaml.version>3.4.1</opensaml.version>
   </properties>
 
   <dependencies>
@@ -59,8 +61,18 @@
     </dependency>
     <dependency>
       <groupId>org.opensaml</groupId>
-      <artifactId>opensaml</artifactId>
-      <version>2.6.4</version>
+      <artifactId>opensaml-core</artifactId>
+      <version>${opensaml.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opensaml</groupId>
+      <artifactId>opensaml-saml-api</artifactId>
+      <version>${opensaml.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opensaml</groupId>
+      <artifactId>opensaml-saml-impl</artifactId>
+      <version>${opensaml.version}</version>
     </dependency>
     <!-- normally transitive via opensaml, bumped here
          to address vulnerabilities -->

--- a/src/main/java/com/coveo/saml/ResponseSchemaValidator.java
+++ b/src/main/java/com/coveo/saml/ResponseSchemaValidator.java
@@ -1,0 +1,45 @@
+package com.coveo.saml;
+
+import org.apache.commons.lang3.StringUtils;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.Response;
+
+import java.util.Objects;
+
+import javax.xml.bind.ValidationException;
+
+public class ResponseSchemaValidator {
+  public void validate(Response response) throws ValidationException {
+    validateStatus(response);
+    validateID(response);
+    validateVersion(response);
+    validateIssueInstant(response);
+  }
+
+  private void validateStatus(Response response) throws ValidationException {
+    if (response.getStatus() == null) {
+      throw new ValidationException("Status is required");
+    }
+  }
+
+  private void validateID(Response response) throws ValidationException {
+    if (StringUtils.isEmpty(response.getID())) {
+      throw new ValidationException("ID attribute must not be empty");
+    }
+  }
+
+  private void validateVersion(Response response) throws ValidationException {
+    if (response.getVersion() == null) {
+      throw new ValidationException("Version attribute must not be null");
+    }
+    if (!Objects.equals(response.getVersion().toString(), SAMLVersion.VERSION_20.toString())) {
+      throw new ValidationException("Wrong SAML Version");
+    }
+  }
+
+  private void validateIssueInstant(Response response) throws ValidationException {
+    if (response.getIssueInstant() == null) {
+      throw new ValidationException("IssueInstant attribute must not be null");
+    }
+  }
+}

--- a/src/main/java/com/coveo/saml/SamlResponse.java
+++ b/src/main/java/com/coveo/saml/SamlResponse.java
@@ -1,6 +1,6 @@
 package com.coveo.saml;
 
-import org.opensaml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Assertion;
 
 public class SamlResponse {
   private Assertion assertion;

--- a/src/main/java/com/coveo/saml/XMLHelper.java
+++ b/src/main/java/com/coveo/saml/XMLHelper.java
@@ -1,0 +1,109 @@
+package com.coveo.saml;
+
+import org.w3c.dom.DOMConfiguration;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSOutput;
+import org.w3c.dom.ls.LSSerializer;
+import org.w3c.dom.ls.LSSerializerFilter;
+
+import java.io.Writer;
+
+import java.util.Map;
+
+public class XMLHelper {
+  /**
+   * Writes a Node out to a Writer using the DOM, level 3, Load/Save serializer. The written content is encoded using
+   * the encoding specified in the writer configuration.
+   *
+   * @param node the node to write out
+   * @param output the writer to write the XML to
+   */
+  public static void writeNode(Node node, Writer output) {
+    writeNode(node, output, null);
+  }
+
+  /**
+   * Writes a Node out to a Writer using the DOM, level 3, Load/Save serializer. The written content is encoded using
+   * the encoding specified in the writer configuration.
+   *
+   * @param node the node to write out
+   * @param output the writer to write the XML to
+   * @param serializerParams parameters to pass to the {@link DOMConfiguration} of the serializer
+   *         instance, obtained via {@link LSSerializer#getDomConfig()}. May be null.
+   */
+  public static void writeNode(Node node, Writer output, Map<String, Object> serializerParams) {
+    DOMImplementationLS domImplLS = getLSDOMImpl(node);
+
+    LSSerializer serializer = getLSSerializer(domImplLS, serializerParams);
+
+    LSOutput serializerOut = domImplLS.createLSOutput();
+    serializerOut.setCharacterStream(output);
+
+    serializer.write(node, serializerOut);
+  }
+
+  /**
+   * Obtain a the DOM, level 3, Load/Save serializer {@link LSSerializer} instance from the
+   * given {@link DOMImplementationLS} instance.
+   *
+   * <p>
+   * The serializer instance will be configured with the parameters passed as the <code>serializerParams</code>
+   * argument. It will also be configured with an {@link LSSerializerFilter} that shows all nodes to the filter,
+   * and accepts all nodes shown.
+   * </p>
+   *
+   * @param domImplLS the DOM Level 3 Load/Save implementation to use
+   * @param serializerParams parameters to pass to the {@link DOMConfiguration} of the serializer
+   *         instance, obtained via {@link LSSerializer#getDomConfig()}. May be null.
+   *
+   * @return a new LSSerializer instance
+   */
+  public static LSSerializer getLSSerializer(
+      DOMImplementationLS domImplLS, Map<String, Object> serializerParams) {
+    LSSerializer serializer = domImplLS.createLSSerializer();
+
+    serializer.setFilter(
+        new LSSerializerFilter() {
+
+          @Override
+          public short acceptNode(Node arg0) {
+            return FILTER_ACCEPT;
+          }
+
+          @Override
+          public int getWhatToShow() {
+            return SHOW_ALL;
+          }
+        });
+
+    if (serializerParams != null) {
+      DOMConfiguration serializerDOMConfig = serializer.getDomConfig();
+      for (String key : serializerParams.keySet()) {
+        serializerDOMConfig.setParameter(key, serializerParams.get(key));
+      }
+    }
+
+    return serializer;
+  }
+
+  /**
+   * Get the DOM Level 3 Load/Save {@link DOMImplementationLS} for the given node.
+   *
+   * @param node the node to evaluate
+   * @return the DOMImplementationLS for the given node
+   */
+  public static DOMImplementationLS getLSDOMImpl(Node node) {
+    DOMImplementation domImpl;
+    if (node instanceof Document) {
+      domImpl = ((Document) node).getImplementation();
+    } else {
+      domImpl = node.getOwnerDocument().getImplementation();
+    }
+
+    DOMImplementationLS domImplLS = (DOMImplementationLS) domImpl.getFeature("LS", "3.0");
+    return domImplLS;
+  }
+}

--- a/src/test/java/com/coveo/saml/SamlClientTest.java
+++ b/src/test/java/com/coveo/saml/SamlClientTest.java
@@ -3,7 +3,6 @@ package com.coveo.saml;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
-import org.opensaml.xml.util.Base64;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -13,6 +12,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Base64;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -74,7 +74,7 @@ public class SamlClientTest {
     SamlClient client =
         SamlClient.fromMetadata(
             "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
-    String decoded = new String(Base64.decode(client.getSamlRequest()), "UTF-8");
+    String decoded = new String(Base64.getDecoder().decode(client.getSamlRequest()), "UTF-8");
     assertTrue(decoded.contains(">myidentifier<"));
   }
 
@@ -117,13 +117,13 @@ public class SamlClientTest {
 
   @Test(expected = SamlException.class)
   public void decodeAndValidateSamlResponseRejectsATamperedResponse() throws Throwable {
-    String decoded = new String(Base64.decode(AN_ENCODED_RESPONSE), "UTF-8");
+    String decoded = new String(Base64.getDecoder().decode(AN_ENCODED_RESPONSE), "UTF-8");
     String tampered = decoded.replace("mlaporte", "evilperson");
     SamlClient client =
         SamlClient.fromMetadata(
             "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
     client.setDateTimeNow(ASSERTION_DATE);
-    client.decodeAndValidateSamlResponse(Base64.encodeBytes(tampered.getBytes("UTF-8")));
+    client.decodeAndValidateSamlResponse(Base64.getEncoder().encodeToString(tampered.getBytes("UTF-8")));
   }
 
   @Test
@@ -163,21 +163,21 @@ public class SamlClientTest {
             "http://some/url",
             getXml("adfs.xml"),
             SamlClient.SamlIdpBinding.Redirect);
-    String decoded = new String(Base64.decode(client.getSamlRequest()), "UTF-8");
+    String decoded = new String(Base64.getDecoder().decode(client.getSamlRequest()), "UTF-8");
     assertTrue(decoded.contains(">myidentifier<"));
   }
 
   // Test for https://www.kb.cert.org/vuls/id/475445
   @Test
   public void itIsNotVulnerableToCommentAttackFromOpenSAML() throws Throwable {
-    String decoded = new String(Base64.decode(AN_ENCODED_RESPONSE), "UTF-8");
+    String decoded = new String(Base64.getDecoder().decode(AN_ENCODED_RESPONSE), "UTF-8");
     String tampered = decoded.replace("mlaporte", "m<!---->laporte");
     SamlClient client =
         SamlClient.fromMetadata(
             "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
     client.setDateTimeNow(ASSERTION_DATE);
     SamlResponse response =
-        client.decodeAndValidateSamlResponse(Base64.encodeBytes(tampered.getBytes("UTF-8")));
+        client.decodeAndValidateSamlResponse(Base64.getEncoder().encodeToString(tampered.getBytes("UTF-8")));
 
     // Since comments are ignored from the signature validation, the decoding will work. Here we
     // ensure that the identity that ends up being returned is the proper one.


### PR DESCRIPTION
I really like this library but am running into some dependency conflicts with WSS4J because it uses OpenSAML 2 (which pulls in a really old version of `org.apache.santuario`:`xmlsec`). Since OpenSAML 3 has been around for a while I took a shot at upgrading `SamlClient` to use it (which was also requested in #9).

All tests are passing and everything seems to work fine.

Can you take a look at this and let us know what you think?