### PR TITLE
Use Apache Base64 instead of the one from Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
       <version>3.4</version>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/src/main/java/com/coveo/saml/SamlClient.java
+++ b/src/main/java/com/coveo/saml/SamlClient.java
@@ -2,6 +2,7 @@ package com.coveo.saml;
 
 import com.sun.org.apache.xerces.internal.parsers.DOMParser;
 
+import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.core.xml.XMLObject;
@@ -40,10 +41,10 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -249,11 +250,7 @@ public class SamlClient {
 
     logger.trace("Issuing SAML request: " + stringWriter.toString());
 
-    try {
-      return Base64.getEncoder().encodeToString(stringWriter.toString().getBytes("UTF-8"));
-    } catch (UnsupportedEncodingException ex) {
-      throw new SamlException("Error while encoding SAML request", ex);
-    }
+    return Base64.encodeBase64String(stringWriter.toString().getBytes(StandardCharsets.UTF_8));
   }
 
   /**
@@ -265,11 +262,7 @@ public class SamlClient {
    */
   public SamlResponse decodeAndValidateSamlResponse(String encodedResponse) throws SamlException {
     String decodedResponse;
-    try {
-      decodedResponse = new String(Base64.getDecoder().decode(encodedResponse), "UTF-8");
-    } catch (UnsupportedEncodingException ex) {
-      throw new SamlException("Cannot decode base64 encoded response", ex);
-    }
+    decodedResponse = new String(Base64.decodeBase64(encodedResponse), StandardCharsets.UTF_8);
 
     logger.trace("Validating SAML response: " + decodedResponse);
 

--- a/src/test/java/com/coveo/saml/SamlClientTest.java
+++ b/src/test/java/com/coveo/saml/SamlClientTest.java
@@ -1,18 +1,18 @@
 package com.coveo.saml;
 
+import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
+import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Base64;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -32,8 +32,9 @@ public class SamlClientTest {
   private static final String AN_ENCODED_RESPONSE_HUB =
       "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHNhbWwycDpSZXNwb25zZSBEZXN0aW5hdGlvbj0iaHR0cHM6Ly9zcHRlc3QuaWFtc2hvd2Nhc2UuY29tL2FjcyIgSUQ9Il8yMDA0NjEzYi1mZDdjLTRkMTctYjAwNy03NGIyN2JmYzhiODIiIEluUmVzcG9uc2VUbz0iYWU4ZDY3N2JlN2U0ZjNiNzcxZjU2NjljMDgwNzcyZGEyNWM1Y2I0YjYiIElzc3VlSW5zdGFudD0iMjAxOC0wOC0xNlQwNjo1NDo0OS44NjZaIiBWZXJzaW9uPSIyLjAiIHhtbG5zOnNhbWwycD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnByb3RvY29sIj48c2FtbDI6SXNzdWVyIHhtbG5zOnNhbWwyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIj5qZXRicmFpbnMuY29tL2h1Yjwvc2FtbDI6SXNzdWVyPjxzYW1sMnA6U3RhdHVzPjxzYW1sMnA6U3RhdHVzQ29kZSBWYWx1ZT0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnN0YXR1czpTdWNjZXNzIi8+PC9zYW1sMnA6U3RhdHVzPjxzYW1sMjpBc3NlcnRpb24gSUQ9Il9lZTk0MzI0Yy0yNWViLTQ3YzktOWZiNi1kZjk2NTRhNjFiOTkiIElzc3VlSW5zdGFudD0iMjAxOC0wOC0xNlQwNjo1NDo0OS44NjZaIiBWZXJzaW9uPSIyLjAiIHhtbG5zOnNhbWwyPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIiB4bWxuczp4cz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiPjxzYW1sMjpJc3N1ZXI+amV0YnJhaW5zLmNvbS9odWI8L3NhbWwyOklzc3Vlcj48ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj48ZHM6U2lnbmVkSW5mbz48ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjxkczpTaWduYXR1cmVNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjcnNhLXNoYTEiLz48ZHM6UmVmZXJlbmNlIFVSST0iI19lZTk0MzI0Yy0yNWViLTQ3YzktOWZiNi1kZjk2NTRhNjFiOTkiPjxkczpUcmFuc2Zvcm1zPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjZW52ZWxvcGVkLXNpZ25hdHVyZSIvPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiPjxlYzpJbmNsdXNpdmVOYW1lc3BhY2VzIFByZWZpeExpc3Q9InhzIiB4bWxuczplYz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS8xMC94bWwtZXhjLWMxNG4jIi8+PC9kczpUcmFuc2Zvcm0+PC9kczpUcmFuc2Zvcm1zPjxkczpEaWdlc3RNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjc2hhMSIvPjxkczpEaWdlc3RWYWx1ZT54NEJwcE12eis0aGt2NEdTQSt6WGRTOFJrZE09PC9kczpEaWdlc3RWYWx1ZT48L2RzOlJlZmVyZW5jZT48L2RzOlNpZ25lZEluZm8+PGRzOlNpZ25hdHVyZVZhbHVlPkpCNjZqUll1NlpRdXBqSG0vSVJDM3ZOcDRiZ1IrQlV0UHRES3FQT2ZOb2FzS1J5c3MycHdERHNkODc0RGxkaGVMNy9YYkZ6RWdZT2R4ZkM3Z1V5S2laYVJTM0NGcHlTWkx0d0pDUE51aEJsMStLZEgraU9KTkZYYnVGakFoQmtCWXU4SklQTWt3UUVNSlhCTFZtSTdicXZIdFNqbmd3bnNkTXFqQ01TcnFRVlBtVmJhZXZReTlJUFhZOUFJQ05WWk4xYXJGUUZIZ3k5Qzh5STlkalZqbCtGMTdmeE1iL2pEZU4yTVI3NUJyUE5UM2p3dnNHamhQWGtuTzlwcWlNREZTV2NQVlhiUGtmaStPNTFiWDFudVdnWnpFTlhieUltZ2R2TXBaSzNUTVpLZVdLbjNIRDl2anJaVjdGTnYydkdJbE4zRUlTVlBNcUdvQVJlRHJpYVg5dz09PC9kczpTaWduYXR1cmVWYWx1ZT48ZHM6S2V5SW5mbz48ZHM6WDUwOURhdGE+PGRzOlg1MDlDZXJ0aWZpY2F0ZT5NSUlET2pDQ0FpSUNDUUN0TEhCMmNuNFZNREFOQmdrcWhraUc5dzBCQVFzRkFEQmZNUXN3Q1FZRFZRUUdFd0pFUlRFTU1Bb0dBMVVFCkNBd0RUbEpYTVJFd0R3WURWUVFIREFoTmRXVnVjM1JsY2pFaE1COEdBMVVFQ2d3WVEyOXVjMlZ1YzJVZ1EyOXVjM1ZzZEdsdVp5QkgKYldKSU1Rd3dDZ1lEVlFRTERBTkVSVll3SGhjTk1UZ3dPREUwTVRJeE5EUTBXaGNOTVRrd09ERTBNVEl4TkRRMFdqQmZNUXN3Q1FZRApWUVFHRXdKRVJURU1NQW9HQTFVRUNBd0RUbEpYTVJFd0R3WURWUVFIREFoTmRXVnVjM1JsY2pFaE1COEdBMVVFQ2d3WVEyOXVjMlZ1CmMyVWdRMjl1YzNWc2RHbHVaeUJIYldKSU1Rd3dDZ1lEVlFRTERBTkVSVll3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXcKZ2dFS0FvSUJBUUN5anRkSWo5azIvRHFrdXliUTZYZkFodVNYeEh0UFZHM2F4bGl4NGJmTk1MVXQ0RGRtVTVDY2hqWisrdXV0bTdTNApvMUp6SWpaalUzdHczcTcxMzl1cnRvZWNvTGdxbWQzM1NoRXlRU0swSVE1Qmdodnp3bTRGWVlWdUdKZnhmQm0xY0FHVzVyNkFNbkF3CmhJRDRYeW9UdDFKUGVjaTZGMU9VRHdaN3oxdUdabFREbEUrY25CMHIxeXhYZW5pVUlwam15MW93Z3Nyb09POUJ1ejRiV0JyUE5pU1UKdkFHU05TVWRuZElhMi9WRCsrK0R2U2RpQU9DdUZCTWw3VUxUMCtpemVYelhBVGZlUUU1QTVEUjhzdHBpcHI4aEJiV0NQS1NHTHI3YQowZGh5TVZDUXRnQ2xMOFlGY0JVOWx4Ti9MS2h1Y0dDamRjWW9MVG56NmtlSDY3THJBZ01CQUFFd0RRWUpLb1pJaHZjTkFRRUxCUUFECmdnRUJBQ2dVRlR5TlQyNXdETXhoTjU1SUJOcFRmbk0zck45bjlUZWsrRUxzdGZjMXdhVlVmblR0VGl1MHlZTy9jMDR6aEttWUphQWsKNzBGS1pKUUtJRU1rbTk1UDVxMkk5MWpJR01PaGJiL21EL3ZCL2lUdHI1U1hYZWFyQ0Z4ZFFKSzVEaUUzZnVQVDQzempDVXVZTHJNVQpGWWFrV0FDRm56aUhZbGtPMWJLdUNwVGtob2JSbFJ4RWI1TW1KL1FVTnV1RTlLV3JUMGw4bVdTeWRGS2ZkckFUMDR2NTJ0TnR4TGV4CkVZa1pCT0xIczAwdDJObzRHK2dkWWJ2NEt4MmlubTllanZHdldTTnlMRHRiZHM0ek83VjRXNVNqZzRITXp2Z3c4c2hvN2FqSEVvd1IKMzRJTVk0bVZYdnlFdmUvR3lsT0EwRDIyRE5UR0NxdmNvV2ZWSTBzSXRVST08L2RzOlg1MDlDZXJ0aWZpY2F0ZT48L2RzOlg1MDlEYXRhPjwvZHM6S2V5SW5mbz48L2RzOlNpZ25hdHVyZT48c2FtbDI6U3ViamVjdD48c2FtbDI6TmFtZUlEIEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6ZW1haWxBZGRyZXNzIj50ZXN0QHRlc3QudGxkPC9zYW1sMjpOYW1lSUQ+PHNhbWwyOlN1YmplY3RDb25maXJtYXRpb24gTWV0aG9kPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6Y206YmVhcmVyIj48c2FtbDI6U3ViamVjdENvbmZpcm1hdGlvbkRhdGEgSW5SZXNwb25zZVRvPSJhZThkNjc3YmU3ZTRmM2I3NzFmNTY2OWMwODA3NzJkYTI1YzVjYjRiNiIgTm90T25PckFmdGVyPSIyMDE4LTA4LTE2VDA2OjU2OjQ5Ljg2NloiIFJlY2lwaWVudD0iaHR0cHM6Ly9zcHRlc3QuaWFtc2hvd2Nhc2UuY29tL2FjcyIvPjwvc2FtbDI6U3ViamVjdENvbmZpcm1hdGlvbj48L3NhbWwyOlN1YmplY3Q+PHNhbWwyOkNvbmRpdGlvbnMgTm90QmVmb3JlPSIyMDE4LTA4LTE2VDA2OjUzOjQ5Ljg2NloiIE5vdE9uT3JBZnRlcj0iMjAxOC0wOC0xNlQwNjo1Njo0OS44NjZaIj48c2FtbDI6QXVkaWVuY2VSZXN0cmljdGlvbj48c2FtbDI6QXVkaWVuY2U+SUFNU2hvd2Nhc2U8L3NhbWwyOkF1ZGllbmNlPjwvc2FtbDI6QXVkaWVuY2VSZXN0cmljdGlvbj48L3NhbWwyOkNvbmRpdGlvbnM+PHNhbWwyOkF1dGhuU3RhdGVtZW50IEF1dGhuSW5zdGFudD0iMjAxOC0wOC0xNlQwNjo1NDo0OS44NjZaIiBTZXNzaW9uSW5kZXg9Il9lYThiYWM3Yy05YmYyLTQ2MWUtYTQxYi1kN2M5ZDA1NTJkNzMiPjxzYW1sMjpBdXRobkNvbnRleHQ+PHNhbWwyOkF1dGhuQ29udGV4dENsYXNzUmVmPnVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphYzpjbGFzc2VzOlBhc3N3b3JkUHJvdGVjdGVkVHJhbnNwb3J0PC9zYW1sMjpBdXRobkNvbnRleHRDbGFzc1JlZj48L3NhbWwyOkF1dGhuQ29udGV4dD48L3NhbWwyOkF1dGhuU3RhdGVtZW50PjxzYW1sMjpBdHRyaWJ1dGVTdGF0ZW1lbnQ+PHNhbWwyOkF0dHJpYnV0ZSBOYW1lPSJ1aWQiIE5hbWVGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphdHRybmFtZS1mb3JtYXQ6YmFzaWMiPjxzYW1sMjpBdHRyaWJ1dGVWYWx1ZSB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4c2k6dHlwZT0ieHM6c3RyaW5nIj50ZXN0PC9zYW1sMjpBdHRyaWJ1dGVWYWx1ZT48L3NhbWwyOkF0dHJpYnV0ZT48c2FtbDI6QXR0cmlidXRlIE5hbWU9ImRpc3BsYXlOYW1lIiBOYW1lRm9ybWF0PSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXR0cm5hbWUtZm9ybWF0OmJhc2ljIj48c2FtbDI6QXR0cmlidXRlVmFsdWUgeG1sbnM6eHNpPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxL1hNTFNjaGVtYS1pbnN0YW5jZSIgeHNpOnR5cGU9InhzOnN0cmluZyI+VGVzdCBVc2VyPC9zYW1sMjpBdHRyaWJ1dGVWYWx1ZT48L3NhbWwyOkF0dHJpYnV0ZT48c2FtbDI6QXR0cmlidXRlIE5hbWU9Im1haWwiIE5hbWVGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphdHRybmFtZS1mb3JtYXQ6YmFzaWMiPjxzYW1sMjpBdHRyaWJ1dGVWYWx1ZSB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4c2k6dHlwZT0ieHM6c3RyaW5nIj50ZXN0QHRlc3QudGxkPC9zYW1sMjpBdHRyaWJ1dGVWYWx1ZT48L3NhbWwyOkF0dHJpYnV0ZT48L3NhbWwyOkF0dHJpYnV0ZVN0YXRlbWVudD48L3NhbWwyOkFzc2VydGlvbj48L3NhbWwycDpSZXNwb25zZT4=";
 
-  private static Reader getXml(String name) throws IOException {
-    return new InputStreamReader(SamlClientTest.class.getResourceAsStream(name), "UTF-8");
+  private static Reader getXml(String name) {
+    return new InputStreamReader(
+        SamlClientTest.class.getResourceAsStream(name), StandardCharsets.UTF_8);
   }
 
   @Test
@@ -80,7 +81,8 @@ public class SamlClientTest {
     SamlClient client =
         SamlClient.fromMetadata(
             "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
-    String decoded = new String(Base64.getDecoder().decode(client.getSamlRequest()), "UTF-8");
+    String decoded =
+        new String(Base64.decodeBase64(client.getSamlRequest()), StandardCharsets.UTF_8);
     assertTrue(decoded.contains(">myidentifier<"));
   }
 
@@ -123,14 +125,14 @@ public class SamlClientTest {
 
   @Test(expected = SamlException.class)
   public void decodeAndValidateSamlResponseRejectsATamperedResponse() throws Throwable {
-    String decoded = new String(Base64.getDecoder().decode(AN_ENCODED_RESPONSE), "UTF-8");
+    String decoded = new String(Base64.decodeBase64(AN_ENCODED_RESPONSE), StandardCharsets.UTF_8);
     String tampered = decoded.replace("mlaporte", "evilperson");
     SamlClient client =
         SamlClient.fromMetadata(
             "myidentifier", "http://some/url", getXml("adfs.xml"), SamlClient.SamlIdpBinding.POST);
     client.setDateTimeNow(ASSERTION_DATE);
     client.decodeAndValidateSamlResponse(
-        Base64.getEncoder().encodeToString(tampered.getBytes("UTF-8")));
+        Base64.encodeBase64String(tampered.getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test
@@ -170,14 +172,15 @@ public class SamlClientTest {
             "http://some/url",
             getXml("adfs.xml"),
             SamlClient.SamlIdpBinding.Redirect);
-    String decoded = new String(Base64.getDecoder().decode(client.getSamlRequest()), "UTF-8");
+    String decoded =
+        new String(Base64.decodeBase64(client.getSamlRequest()), StandardCharsets.UTF_8);
     assertTrue(decoded.contains(">myidentifier<"));
   }
 
   // Test for https://www.kb.cert.org/vuls/id/475445
   @Test
   public void itIsNotVulnerableToCommentAttackFromOpenSAML() throws Throwable {
-    String decoded = new String(Base64.getDecoder().decode(AN_ENCODED_RESPONSE), "UTF-8");
+    String decoded = new String(Base64.decodeBase64(AN_ENCODED_RESPONSE), StandardCharsets.UTF_8);
     String tampered = decoded.replace("mlaporte", "m<!---->laporte");
     SamlClient client =
         SamlClient.fromMetadata(
@@ -185,7 +188,7 @@ public class SamlClientTest {
     client.setDateTimeNow(ASSERTION_DATE);
     SamlResponse response =
         client.decodeAndValidateSamlResponse(
-            Base64.getEncoder().encodeToString(tampered.getBytes("UTF-8")));
+            Base64.encodeBase64String(tampered.getBytes(StandardCharsets.UTF_8)));
 
     // Since comments are ignored from the signature validation, the decoding will work. Here we
     // ensure that the identity that ends up being returned is the proper one.


### PR DESCRIPTION
@totof3110 mentions that he had problem with some claims when decoded through Java's own Base64 decoder. I don't know why that would fail ... but hey the switch to the Apache decoder is easy enough.